### PR TITLE
Two different variables are initialized by the same expression

### DIFF
--- a/source/Process/Misc/Alloc.cpp
+++ b/source/Process/Misc/Alloc.cpp
@@ -46,7 +46,7 @@ InvokeDealloc(
 {
     FBlock& block = cargs->dst;
     auto w = block.Width();
-    auto h = block.Width();
+    auto h = block.Height();
     auto fmt = block.Format();
     auto cs = block.ColorSpace();
     cargs->dst.LoadFromData( nullptr, w, h, fmt, nullptr, FOnInvalidBlock(), FOnCleanupData( &OnCleanup_FreeMemory ) );


### PR DESCRIPTION
#2 
Variables are initialized through the call to the same function. It's probably an error.